### PR TITLE
Bind to All Datastores for easy backup/restore

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -14,5 +14,10 @@ applications:
     services:
       - datastore-backups
       - dashboard-db
+      - dashboard-s3
       - catalog-db
-      - catalog-db-migrate
+      - catalog-redis
+      - inventory-datastore
+      - inventory-db
+      - inventory-redis
+      - inventory-s3


### PR DESCRIPTION
Best to merge when all apps/services have datastore functionality on cloud.gov