### PR TITLE
clean before restore

### DIFF
--- a/docs/fcs_migration/02-fcs-catalog-db-restore.sh
+++ b/docs/fcs_migration/02-fcs-catalog-db-restore.sh
@@ -53,7 +53,7 @@ EOF
 
 # Restore backup
 restore_id=$$
-time cf run-task backup-manager --name "catalog-restore-$restore_id" --command "PG_RESTORE_OPTIONS='--no-acl' restore psql $catalog_db_migrate $backup_path"
+time cf run-task backup-manager --name "catalog-restore-$restore_id" --command "PG_RESTORE_OPTIONS='--if-exists --clean --no-acl' restore psql $catalog_db_migrate $backup_path"
 
 # This job may return "FAILED", and may not return successfully
 wait_for "catalog-restore-$restore_id"


### PR DESCRIPTION
Add `--if-exists --clean` to the pg_restore option to get rid the following error. The error is more like a harmless warning but it does halt the script from completing.

```
pg_restore: while PROCESSING TOC:
pg_restore: from TOC entry 4; 2615 2200 SCHEMA public postgres
pg_restore: error: could not execute query: ERROR:  schema "public" already exists
Command was: CREATE SCHEMA public;
```