### PR TITLE
Add redis for debugging redis 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk update && apk add \
   mysql-client \
   ncurses \
   postgresql-client \
-  python3
+  python3 \
+  redis
 
 COPY bin/ /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,23 @@ RUN apk update && apk add \
   ncurses \
   postgresql-client \
   python3 \
-  redis
+  redis \
+  stunnel
 
+# Add local scripts to global scope
 COPY bin/ /usr/local/bin/
 
+# Create non-privileged user
 RUN adduser -S backup-manager -h /app
+
+# Setup stunnel for secure redis connection
+#  - Make stunnel executable by anyone
+#  - Create folder for background processes
+RUN chmod u+s /usr/bin/stunnel
+RUN mkdir /app/pids
+RUN chown -R backup-manager /app/pids
+
+# Set user and starting env
 USER backup-manager
 
 COPY . /app/

--- a/docs/redis-support.md
+++ b/docs/redis-support.md
@@ -1,0 +1,83 @@
+# Connecting to and Debugging a Cloud.gov Redis Service
+
+The motivation for this feature/functionality was when the Data.gov catalog redis
+service became full and started to give the following error.
+```bash
+Redis Exception: OOM command not allowed when usedmemory > `maxmemory`
+```
+
+Unlike the database backup/restore scripts, There is currently no automated or
+scripted version of these steps because they are lightweight enough that they
+can be easily duplicated and are very application-specific.
+
+## Deploy backup-manager to cloud.gov space
+
+This is assumed to be pipeline-specific and out-of-scope for this guide.
+
+## SSH onto backup-manager
+
+If SSH access is not enabled:
+```bash
+cf allow-space-ssh <space>
+cf enable-ssh backup-manager
+cf rs backup-manager
+```
+
+## Configure Redis Connection details
+
+Grab/Generate a key to initiate a connection with redis:
+```bash
+cf csk <redis-service> <new-key-name>
+cf service-key <redis-service> <new-key-name>
+```
+
+Create a file with any name.  We will use `stunnel.conf` for this guide.
+Use the host and port referenced above to substitute `<redis-server-host>`
+and `<redis-server-port>` in the template below.
+```py
+fips = no
+setuid = nobody
+setgid = nogroup
+pid = /app/pids/stunnel.pid
+debug = 7
+delay = yes
+socket = l:TCP_NODELAY=1
+socket = r:TCP_NODELAY=1
+[redis-cli]
+  client = yes
+  accept = 127.0.0.1:8000
+  connect = <redis-server-host>:<redis-server-port>
+```
+
+Note: multiple redis connections can be defined, just copy the `[redis-cli]`
+block and change the block name, port number and connect details, e.g.
+```py
+[redis-cli2]
+  client = yes
+  accept = 127.0.0.1:8002
+  connect = <redis-server2-host>:<redis-server2-port>
+```
+
+## Start stunnel
+
+Run the following command with the path+filename that you created above.
+If it is in the same directory, the path is not necessary.
+```bash
+stunnel stunnel.conf
+```
+
+## Run the redis-cli
+
+Run the following command to initiate a connection with the redis service:
+```bash
+redis-cli -h localhost -p 8000
+```
+
+For cloud.gov applications, the redis service requires a password.  Once
+the cli is initiated, substitute `<redis-server-password>` with the value
+from the above key:
+```bash
+localhost:8000> AUTH <redis-server-password>
+```
+
+From here you can now run any Redis commands such as `ping` and `info` 🙂


### PR DESCRIPTION
Related to
- https://github.com/GSA/data.gov/issues/4188

Changes:
- Add `redis` package to have access to the `redis-cli` command
- Because `redis-cli` is insecure by default, most redis servers require an TLS Encryption-in-transit which is being taken care of by adding and configuring `stunnel`
  - It should be noted that [`stunnel`](https://pkgs.alpinelinux.org/packages?name=*stunnel*&branch=v3.15&repo=&arch=&maintainer=) is only available up to `alpine:3.15` after which time [`tlstunnel`](https://pkgs.alpinelinux.org/packages?name=*stunnel*&branch=v3.16&repo=&arch=&maintainer=) is present.  I could not get it to work with `tlstunnel`, however, if the base image is ever updated to `3.16+`, this solution will need to be revamped.

Notes/References:
- [How To Connect to a Managed Redis Instance over TLS with Stunnel and redis-cli](https://www.digitalocean.com/community/tutorials/how-to-connect-to-managed-redis-over-tls-with-stunnel-and-redis-cli) was used as the base guide to get this to work.
- https://github.com/ncopa/su-exec/issues/2#issuecomment-202873774 highlighted a way for a non-privileged user to execute a script as root which was needed to get `backup-manager` user to be able to run `stunnel` which needed root permissions to use the `setgroups` command.  This is technically escalating a non-privileged user, but I don't think there's any security threat from this approach.
- Using REDISCLI_AUTH to set [redis authentication](https://stackoverflow.com/a/64372000).  Although this has been superseded by using the [AUTH redis command](https://serverfault.com/a/741069).
- How to search a Redis server for a [randomkey](https://stackoverflow.com/a/43929549).
- How to use [`SCAN`](https://redis.io/commands/scan/) to search a Redis server.