### PR TITLE
upgrade alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.17
 
 RUN apk update && apk add \
   aws-cli \
@@ -9,7 +9,7 @@ RUN apk update && apk add \
   postgresql-client \
   python3 \
   redis \
-  stunnel
+  stunnel 
 
 # Add local scripts to global scope
 COPY bin/ /usr/local/bin/

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,21 @@
 BATS_ARGS:=--recursive --pretty
 
 build:
-	docker-compose build
+	docker compose build
 
 clean:
-	docker-compose down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 production:
 	docker build . -t ghcr.io/gsa/cf-backup-manager:latest
 
 test:
-	docker-compose run --rm app test/bats/bin/bats $(BATS_ARGS) test/*.bats
+	docker compose run --rm app test/bats/bin/bats $(BATS_ARGS) test/*.bats
 
 up:
-	docker-compose up -d
+	docker compose up -d
 
+down:
+	docker compose down
 
 .PHONY: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: "3.7"
 services:
   app:
     build: .


### PR DESCRIPTION
related to [#4880](https://github.com/GSA/data.gov/issues/4880) &  [#4885](https://github.com/GSA/data.gov/issues/4885)

bumping the alpine version gets us 15.x pg client. confirmed by running `pg_dump --version` in container locally